### PR TITLE
Add support for newer Sparc servers

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -36,7 +36,7 @@ case "$my_arch" in
     mybits="64"
     mybits_install="64"
     ;;
-  *sparc*)
+  *sparc*|sun4u|sun4v)
     mybits="64"
     mybits_install="64"
     is_sparc="yes"


### PR DESCRIPTION
This includes e.g. an M3000 and a T5220 among other machines with SPARC64 and T-series CPUs
